### PR TITLE
Install models to users homedirectory instead of globally

### DIFF
--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -64,7 +64,7 @@ def download_model(filename):
     util.print_msg("Downloading {f}".format(f=filename))
     download_url = about.__download_url__ + '/' + filename
     subprocess.call([sys.executable, '-m',
-        'pip', 'install', '--no-cache-dir', download_url],
+        'pip', 'install', '--user', '--no-cache-dir', download_url],
         env=os.environ.copy())
 
 


### PR DESCRIPTION
Use pip install --user. It is not advisable to install the packages globally as this not only requires root access on the machine, [but also messes with files managed by the system package manager](https://wiki.gentoo.org/wiki/Pip#Package_installation) (apt-get, emerge, ...)